### PR TITLE
feat: strip Obsidian callout markers and convert markdown lists to HTML in extraction

### DIFF
--- a/src/sync/extractionUtils.ts
+++ b/src/sync/extractionUtils.ts
@@ -50,7 +50,8 @@ function parseImagePath(text: string): string | null {
 }
 
 /**
- * Converts markdown lists (unordered and ordered) to HTML list elements
+ * Converts markdown lists (unordered and ordered) to HTML list elements.
+ * Supports nested lists via indentation (tabs or 2-space units).
  */
 function convertMarkdownListsToHtml(text: string): string {
   if (!text) return text;
@@ -58,48 +59,74 @@ function convertMarkdownListsToHtml(text: string): string {
   const result: string[] = [];
   let i = 0;
 
+  function getDepth(indent: string): number {
+    if (indent.includes('\t')) return indent.length;
+    return indent.length > 0 ? Math.floor(indent.length / 2) : 0;
+  }
+
+  function renderNestedList(
+    items: { depth: number; isOrdered: boolean; content: string }[],
+    startIdx: number,
+    parentDepth: number,
+  ): { html: string; endIdx: number } {
+    if (startIdx >= items.length || items[startIdx].depth <= parentDepth) {
+      return { html: '', endIdx: startIdx };
+    }
+
+    const type = items[startIdx].isOrdered ? 'ol' : 'ul';
+    const parts: string[] = [`<${type}>`];
+    let idx = startIdx;
+
+    while (idx < items.length) {
+      const item = items[idx];
+      if (item.depth <= parentDepth) break;
+
+      if (item.depth === parentDepth + 1) {
+        let nestedHtml = '';
+        if (idx + 1 < items.length && items[idx + 1].depth > item.depth) {
+          const nested = renderNestedList(items, idx + 1, item.depth);
+          nestedHtml = nested.html;
+          idx = nested.endIdx;
+        } else {
+          idx++;
+        }
+
+        if (nestedHtml) {
+          parts.push(`<li>${item.content}\n${nestedHtml}\n</li>`);
+        } else {
+          parts.push(`<li>${item.content}</li>`);
+        }
+      } else {
+        idx++;
+      }
+    }
+
+    parts.push(`</${type}>`);
+    return { html: parts.join('\n'), endIdx: idx };
+  }
+
   while (i < lines.length) {
-    const line = lines[i];
-
-    // Unordered list: lines starting with "- " or "* "
-    const ulMatch = line.match(/^[-*]\s+(.*)/);
-    if (ulMatch) {
-      const items: string[] = [ulMatch[1]];
-      i++;
+    const listMatch = lines[i].match(/^(\s*)([-*]|\d+\.)\s+(.*)/);
+    if (listMatch) {
+      const items: { depth: number; isOrdered: boolean; content: string }[] = [];
       while (i < lines.length) {
-        const nextMatch = lines[i].match(/^[-*]\s+(.*)/);
-        if (!nextMatch) break;
-        items.push(nextMatch[1]);
+        const m = lines[i].match(/^(\s*)([-*]|\d+\.)\s+(.*)/);
+        if (!m) break;
+        items.push({
+          depth: getDepth(m[1]),
+          isOrdered: /^\d+\.$/.test(m[2]),
+          content: m[3],
+        });
         i++;
       }
-      result.push('<ul>');
-      for (const item of items) {
-        result.push(`<li>${item}</li>`);
+      if (items.length > 0) {
+        const { html } = renderNestedList(items, 0, -1);
+        result.push(html);
       }
-      result.push('</ul>');
       continue;
     }
 
-    // Ordered list: lines starting with digit(s). and space
-    const olMatch = line.match(/^\d+\.\s+(.*)/);
-    if (olMatch) {
-      const items: string[] = [olMatch[1]];
-      i++;
-      while (i < lines.length) {
-        const nextMatch = lines[i].match(/^\d+\.\s+(.*)/);
-        if (!nextMatch) break;
-        items.push(nextMatch[1]);
-        i++;
-      }
-      result.push('<ol>');
-      for (const item of items) {
-        result.push(`<li>${item}</li>`);
-      }
-      result.push('</ol>');
-      continue;
-    }
-
-    result.push(line);
+    result.push(lines[i]);
     i++;
   }
 

--- a/src/sync/extractionUtils.ts
+++ b/src/sync/extractionUtils.ts
@@ -50,6 +50,63 @@ function parseImagePath(text: string): string | null {
 }
 
 /**
+ * Converts markdown lists (unordered and ordered) to HTML list elements
+ */
+function convertMarkdownListsToHtml(text: string): string {
+  if (!text) return text;
+  const lines = text.split('\n');
+  const result: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Unordered list: lines starting with "- " or "* "
+    const ulMatch = line.match(/^[-*]\s+(.*)/);
+    if (ulMatch) {
+      const items: string[] = [ulMatch[1]];
+      i++;
+      while (i < lines.length) {
+        const nextMatch = lines[i].match(/^[-*]\s+(.*)/);
+        if (!nextMatch) break;
+        items.push(nextMatch[1]);
+        i++;
+      }
+      result.push('<ul>');
+      for (const item of items) {
+        result.push(`<li>${item}</li>`);
+      }
+      result.push('</ul>');
+      continue;
+    }
+
+    // Ordered list: lines starting with digit(s). and space
+    const olMatch = line.match(/^\d+\.\s+(.*)/);
+    if (olMatch) {
+      const items: string[] = [olMatch[1]];
+      i++;
+      while (i < lines.length) {
+        const nextMatch = lines[i].match(/^\d+\.\s+(.*)/);
+        if (!nextMatch) break;
+        items.push(nextMatch[1]);
+        i++;
+      }
+      result.push('<ol>');
+      for (const item of items) {
+        result.push(`<li>${item}</li>`);
+      }
+      result.push('</ol>');
+      continue;
+    }
+
+    result.push(line);
+    i++;
+  }
+
+  return result.join('\n');
+}
+
+/**
  * Extracts Q&A cards from text content
  * @param content The text content to extract cards from
  * @param settings Plugin settings containing question/answer words
@@ -78,7 +135,12 @@ export function extractQACardsFromText(content: string, settings: PandaZapSettin
     const iStartRegex = new RegExp(`^(?:[*_]{0,2})${escI}\\s*(.*)`, 'i');
 
     for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
+      let line = lines[i];
+
+      // Strip blockquote/callout markers
+      const cleanedLine = line.replace(/^> ?/, '');
+      if (/^\[!/.test(cleanedLine)) continue;
+      line = cleanedLine;
 
       // 1. Single-line check
       // Check for: Q: ... A: ... I: ... (all on one line)
@@ -90,7 +152,7 @@ export function extractQACardsFromText(content: string, settings: PandaZapSettin
       if (matchAll) {
         cards.push({
           question: matchAll[1].replace(/[*_]+/g, '').trim(),
-          answer: matchAll[2].replace(/[*_]+/g, '').trim(),
+          answer: convertMarkdownListsToHtml(matchAll[2].replace(/[*_]+/g, '').trim()),
           image: parseImagePath(matchAll[3]) || undefined,
           line: i + 1,
         });
@@ -132,7 +194,7 @@ export function extractQACardsFromText(content: string, settings: PandaZapSettin
         if (!iPattern.test(possibleAnswer)) {
           cards.push({
             question: matchQA[1].replace(/[*_]+/g, '').trim(),
-            answer: possibleAnswer.replace(/[*_]+/g, '').trim(),
+            answer: convertMarkdownListsToHtml(possibleAnswer.replace(/[*_]+/g, '').trim()),
             line: i + 1,
           });
           continue;
@@ -156,7 +218,15 @@ export function extractQACardsFromText(content: string, settings: PandaZapSettin
         // Scan ahead
         let j = i + 1;
         while (j < lines.length) {
-          const nextLine = lines[j];
+          let nextLine = lines[j];
+
+          // Strip blockquote/callout markers
+          const cleanedNextLine = nextLine.replace(/^> ?/, '');
+          if (/^\[!/.test(cleanedNextLine)) {
+            j++;
+            continue;
+          }
+          nextLine = cleanedNextLine;
 
           // Stop on blank line (end of card)
           if (nextLine.trim() === '') break;
@@ -209,7 +279,7 @@ export function extractQACardsFromText(content: string, settings: PandaZapSettin
         if (hasAnswer || imagePath) {
           cards.push({
             question: questionText.replace(/[*_]+/g, '').trim(),
-            answer: answerLines.join('\n').trim(),
+            answer: convertMarkdownListsToHtml(answerLines.join('\n').trim()),
             image: imagePath || undefined,
             line: i + 1,
           });

--- a/src/sync/extractionUtils.ts
+++ b/src/sync/extractionUtils.ts
@@ -137,8 +137,8 @@ export function extractQACardsFromText(content: string, settings: PandaZapSettin
     for (let i = 0; i < lines.length; i++) {
       let line = lines[i];
 
-      // Strip blockquote/callout markers
-      const cleanedLine = line.replace(/^> ?/, '');
+      // Strip blockquote/callout markers (handle nested callouts > >)
+      const cleanedLine = line.replace(/^(?:> ?)+/, '');
       if (/^\[!/.test(cleanedLine)) continue;
       line = cleanedLine;
 
@@ -220,8 +220,8 @@ export function extractQACardsFromText(content: string, settings: PandaZapSettin
         while (j < lines.length) {
           let nextLine = lines[j];
 
-          // Strip blockquote/callout markers
-          const cleanedNextLine = nextLine.replace(/^> ?/, '');
+          // Strip blockquote/callout markers (handle nested callouts > >)
+          const cleanedNextLine = nextLine.replace(/^(?:> ?)+/, '');
           if (/^\[!/.test(cleanedNextLine)) {
             j++;
             continue;

--- a/tests/extraction.test.ts
+++ b/tests/extraction.test.ts
@@ -200,4 +200,40 @@ Then you can begin.`;
     expect(cards[0].question).toBe('Who was George Thomas?');
     expect(cards[0].answer).toBe('An American general known as the "Rock of Chickamauga"\nHe served in the Union Army during the Civil War');
   });
+
+  it('should handle nested callout blocks with lists in answers', () => {
+    const content = `> [!NOTE]-
+> George Thomas
+>
+> > [!question]- What is A?
+> > Q: What is A?
+> > A:
+> > - George Thomas was from Ireland.
+> > - He was a mercenary commander for the Marathas.
+>
+> > [!question]- What is B?
+> > Q: What is B?
+> > A:
+> > - He attacked Jaipur, Udaipur, and Bikaner.
+> > - In 1800 A.D., he used the term "Rajputana" for the Rajasthan region for the first time.
+>
+> > [!question]- What is C?
+> > Q: What is C?
+> > A:
+> > - In 1805 A.D., William Franklin published a book titled Military Memoirs of George Thomas.
+> > - He is also known as "Jahazi Firangi."`;
+
+    const cards = extractQACardsFromText(content, defaultSettings);
+
+    expect(cards).toHaveLength(3);
+
+    expect(cards[0].question).toBe('What is A?');
+    expect(cards[0].answer).toBe('<ul>\n<li>George Thomas was from Ireland.</li>\n<li>He was a mercenary commander for the Marathas.</li>\n</ul>');
+
+    expect(cards[1].question).toBe('What is B?');
+    expect(cards[1].answer).toBe('<ul>\n<li>He attacked Jaipur, Udaipur, and Bikaner.</li>\n<li>In 1800 A.D., he used the term "Rajputana" for the Rajasthan region for the first time.</li>\n</ul>');
+
+    expect(cards[2].question).toBe('What is C?');
+    expect(cards[2].answer).toBe('<ul>\n<li>In 1805 A.D., William Franklin published a book titled Military Memoirs of George Thomas.</li>\n<li>He is also known as "Jahazi Firangi."</li>\n</ul>');
+  });
 });

--- a/tests/extraction.test.ts
+++ b/tests/extraction.test.ts
@@ -79,7 +79,7 @@ It was created by Facebook`;
 
     expect(cards).toHaveLength(1);
     expect(cards[0].question).toBe('What are the types of fruit?');
-    expect(cards[0].answer).toBe('- Apple\n- Banana\n- Orange');
+    expect(cards[0].answer).toBe('<ul>\n<li>Apple</li>\n<li>Banana</li>\n<li>Orange</li>\n</ul>');
   });
 
   it('should capture tables after Q: without explicit A:', () => {
@@ -106,7 +106,7 @@ It was created by Facebook`;
 
     expect(cards).toHaveLength(1);
     expect(cards[0].question).toBe('Key features?');
-    expect(cards[0].answer).toBe('- Fast\n- Reliable\n- Scalable');
+    expect(cards[0].answer).toBe('<ul>\n<li>Fast</li>\n<li>Reliable</li>\n<li>Scalable</li>\n</ul>');
   });
 
   it('should capture mixed content after Q: as answer', () => {
@@ -119,6 +119,85 @@ It was created by Facebook`;
 
     expect(cards).toHaveLength(1);
     expect(cards[0].question).toBe('Steps to deploy');
-    expect(cards[0].answer).toBe('1. Build the app\n2. Run tests\n3. Deploy to server');
+    expect(cards[0].answer).toBe('<ol>\n<li>Build the app</li>\n<li>Run tests</li>\n<li>Deploy to server</li>\n</ol>');
+  });
+
+  it('should strip callout markers and skip callout headers', () => {
+    const content = `> [!question]
+> Q: What is the capital of France?
+> A: Paris`;
+
+    const cards = extractQACardsFromText(content, defaultSettings);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].question).toBe('What is the capital of France?');
+    expect(cards[0].answer).toBe('Paris');
+  });
+
+  it('should convert unordered list (-) to HTML', () => {
+    const content = `Q: What are fruits?
+A:
+- Apple
+- Banana
+- Orange`;
+
+    const cards = extractQACardsFromText(content, defaultSettings);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].question).toBe('What are fruits?');
+    expect(cards[0].answer).toBe('<ul>\n<li>Apple</li>\n<li>Banana</li>\n<li>Orange</li>\n</ul>');
+  });
+
+  it('should convert unordered list (*) to HTML', () => {
+    const content = `Q: Key features?
+* Fast
+* Reliable
+* Scalable`;
+
+    const cards = extractQACardsFromText(content, defaultSettings);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].question).toBe('Key features?');
+    expect(cards[0].answer).toBe('<ul>\n<li>Fast</li>\n<li>Reliable</li>\n<li>Scalable</li>\n</ul>');
+  });
+
+  it('should convert ordered list to HTML', () => {
+    const content = `Q: Process
+1. Plan
+2. Execute
+3. Review`;
+
+    const cards = extractQACardsFromText(content, defaultSettings);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].question).toBe('Process');
+    expect(cards[0].answer).toBe('<ol>\n<li>Plan</li>\n<li>Execute</li>\n<li>Review</li>\n</ol>');
+  });
+
+  it('should handle mixed content with text before and after list', () => {
+    const content = `Q: Describe the process
+First, you need to prepare.
+- Gather materials
+- Set up workspace
+Then you can begin.`;
+
+    const cards = extractQACardsFromText(content, defaultSettings);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].question).toBe('Describe the process');
+    expect(cards[0].answer).toBe('First, you need to prepare.\n<ul>\n<li>Gather materials</li>\n<li>Set up workspace</li>\n</ul>\nThen you can begin.');
+  });
+
+  it('should handle Q&A inside callout blocks (George Thomas example)', () => {
+    const content = `> [!question] George Thomas
+> Q: Who was George Thomas?
+> A: An American general known as the "Rock of Chickamauga"
+> He served in the Union Army during the Civil War`;
+
+    const cards = extractQACardsFromText(content, defaultSettings);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].question).toBe('Who was George Thomas?');
+    expect(cards[0].answer).toBe('An American general known as the "Rock of Chickamauga"\nHe served in the Union Army during the Civil War');
   });
 });

--- a/tests/extraction.test.ts
+++ b/tests/extraction.test.ts
@@ -236,4 +236,23 @@ Then you can begin.`;
     expect(cards[2].question).toBe('What is C?');
     expect(cards[2].answer).toBe('<ul>\n<li>In 1805 A.D., William Franklin published a book titled Military Memoirs of George Thomas.</li>\n<li>He is also known as "Jahazi Firangi."</li>\n</ul>');
   });
+
+  it('should convert nested lists with tab indentation to nested HTML', () => {
+    const content = `Q: Nested list example
+A:
+- One
+\t- Two
+\t\t- Three
+- Four
+\t- Five
+\t\t- Six`;
+
+    const cards = extractQACardsFromText(content, defaultSettings);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].question).toBe('Nested list example');
+    expect(cards[0].answer).toBe(
+      '<ul>\n<li>One\n<ul>\n<li>Two\n<ul>\n<li>Three</li>\n</ul>\n</li>\n</ul>\n</li>\n<li>Four\n<ul>\n<li>Five\n<ul>\n<li>Six</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>'
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Two improvements to the Q&A card extraction logic, plus nested callout and nested list support:

### 1. Obsidian Callout Support
Cards written inside `> [!note]` / `> [!question]` / etc. callout blocks are now correctly extracted. All leading `> ` prefixes are stripped from each line (handles nested callouts like `> > [!question]`), and callout header lines are skipped entirely.

### 2. Markdown List → HTML Conversion
Answer content containing markdown lists is now converted to proper HTML (`<ul>`/`<ol>` with `<li>` items) before being sent to Anki. This ensures lists render correctly in Anki cards.

**Before:** `- Apple\n- Banana\n- Orange` (raw markdown — unstyled in Anki)
**After:** `<ul><li>Apple</li><li>Banana</li><li>Orange</li></ul>` (properly rendered list)

### 3. Nested Callout Fix
Changed the stripping regex from `/^> ?/` to `/^(?:> ?)+/` to handle nested Obsidian callouts (e.g. `> > [!question]`), where each nesting level adds another `> ` prefix.

### 4. Nested/Indented List Support
Rewrote `convertMarkdownListsToHtml` to use a recursive approach that tracks indentation depth (tabs or 2-space units). Nested lists are properly wrapped as `<ul>` inside the parent `<li>`.

## Changes
- `src/sync/extractionUtils.ts` — Callout stripping (single + nested), recursive `convertMarkdownListsToHtml()`, applied to all answer output paths
- `tests/extraction.test.ts` — Updated 3 existing list tests; added 8 new tests (callout stripping, `-`/`*` unordered lists, ordered lists, mixed content, callout + Q&A, nested callouts with lists, nested indented lists)

Closes #63